### PR TITLE
Use module format for constant instead of JSON

### DIFF
--- a/lib/default-attributes.js
+++ b/lib/default-attributes.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = {
+  src: 'about:blank',
+  frameBorder: 0,
+  allowtransparency: true,
+  scrolling: 'no'
+};

--- a/lib/default-attributes.json
+++ b/lib/default-attributes.json
@@ -1,6 +1,0 @@
-{
-  "src": "about:blank",
-  "frameBorder": 0,
-  "allowtransparency": true,
-  "scrolling": "no"
-}


### PR DESCRIPTION
Using the module system will make supporting Webpack easier as it won't require a JSON loader.
