### PR TITLE
"iFrame" → "iframe"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-iFramer
+iframer
 =======
 
-A utility to allow consistent iFrame creation.
+A utility to allow consistent iframe creation.
 
 ## Example
 
 ```javascript
-var iFramer = require('iframer');
+var iframer = require('iframer');
 
-var myIframe = iFramer({
+var myIframe = iframer({
   name: 'braintree-dropin-iframe',
   style: 'z-index: 999',
   width: '100%',

--- a/test/iframer.js
+++ b/test/iframer.js
@@ -1,14 +1,14 @@
-var iFramer = require('../index');
+var iframer = require('../index');
 
-describe('iFramer', function () {
-  it('returns an iFrame element', function () {
-    var result = iFramer();
+describe('iframer', function () {
+  it('returns an iframe element', function () {
+    var result = iframer();
 
     expect(result).to.be.an.instanceof(HTMLIFrameElement);
   });
 
   it('applies default attribtutes', function () {
-    var result = iFramer();
+    var result = iframer();
 
     expect(result.getAttribute('src')).to.equal('about:blank');
     expect(result.getAttribute('frameborder')).to.equal('0');
@@ -17,7 +17,7 @@ describe('iFramer', function () {
   });
 
   it('sets attributes', function () {
-    var result = iFramer({
+    var result = iframer({
       frameborder: '10',
       width: '40%'
     });
@@ -28,19 +28,19 @@ describe('iFramer', function () {
 
   describe('id', function () {
     it('defaults to empty', function () {
-      var result = iFramer();
+      var result = iframer();
 
       expect(result.id).to.equal('');
     });
 
     it('is set to match name', function () {
-      var result = iFramer({name: 'foo'});
+      var result = iframer({name: 'foo'});
 
       expect(result.id).to.equal('foo');
     });
 
     it('will use passed in id over name', function () {
-      var result = iFramer({name: 'foo', id: 'bar'});
+      var result = iframer({name: 'foo', id: 'bar'});
 
       expect(result.id).to.equal('bar');
     });
@@ -48,13 +48,13 @@ describe('iFramer', function () {
 
   describe('style', function () {
     it('applies styles as a string', function () {
-      var result = iFramer({style: 'background: tomato; transition: color 100ms;'});
+      var result = iframer({style: 'background: tomato; transition: color 100ms;'});
 
       expect(result.getAttribute('style')).to.equal('background: tomato; transition: color 100ms;');
     });
 
     it('applies styles as an object', function () {
-      var result = iFramer({
+      var result = iframer({
         style: {
           backgroundColor: 'rgb(123, 0, 123)',
           width: '3em'


### PR DESCRIPTION
Our writing style says to write "iframe", not "iFrame". This updates the library to reflect that.

All tests pass after these changes.
