### PR TITLE
Remove unused Gulp dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   "devDependencies": {
     "browserify": "^9.0.8",
     "chai": "^2.2.0",
-    "gulp": "^3.8.11",
     "karma": "^0.12.31",
     "karma-browserify": "^4.1.2",
     "karma-chai": "^0.1.0",


### PR DESCRIPTION
It doesn't look like we use Gulp anywhere, so I removed it.