### PR TITLE
Add Security Workflows

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,24 @@
+name: Security
+
+permissions:
+  contents: write         # Needed by both CodeQL and dependency review
+  pull-requests: write    # Needed by dependency review
+  statuses: write         # Needed by dependency review (to post checks)
+  security-events: write  # Needed by CodeQL to upload SARIF
+  packages: read          # Needed by CodeQL for private/internal packs
+  actions: read           # Needed by CodeQL to access internal actions
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  codeql-javascript:
+    uses: braintree/security-workflows/.github/workflows/codeql.yml@main
+    with:
+      language: javascript-typescript
+  dependency-review:
+    uses: braintree/security-workflows/.github/workflows/dependency-review.yml@main


### PR DESCRIPTION
Adds security workflows as PCI related repos are required to have security scans. Runs with minimal permissions.