### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,4 +14,4 @@ permissions:
 
 jobs:
   ci:
-    uses: braintree/web-sdk-github-actions/.github/workflows/ci.yml@17a3922575160e8e3ffdb7ecc76c6a3dbfd6a50a
+    uses: braintree/web-sdk-github-actions/.github/workflows/ci.yml@7a0129438dde00a728cc851ce2cab9820bb264ed  # main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   publish:
-    uses: braintree/web-sdk-github-actions/.github/workflows/publish.yml@main
+    uses: braintree/web-sdk-github-actions/.github/workflows/release-pipeline.yml@7a0129438dde00a728cc851ce2cab9820bb264ed  # main
     with:
       version-type: ${{ inputs.version_type }}
     secrets:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -17,8 +17,8 @@ on:
 
 jobs:
   codeql-javascript:
-    uses: braintree/security-workflows/.github/workflows/codeql.yml@main
+    uses: braintree/security-workflows/.github/workflows/codeql.yml@c8038c54b62baeabff63eba5a29f7c28ebac6214  # main
     with:
       language: javascript-typescript
   dependency-review:
-    uses: braintree/security-workflows/.github/workflows/dependency-review.yml@main
+    uses: braintree/security-workflows/.github/workflows/dependency-review.yml@c8038c54b62baeabff63eba5a29f7c28ebac6214  # main


### PR DESCRIPTION
# Summary of changes

- Pins GitHub Actions and reusable workflow references to full-length commit SHAs, per GitHub's secure-use guidance for third-party actions. SHA-pinned refs carry a trailing comment with the original tag/branch for readability.
- Also retargets the publish job from the shared `publish.yml` to `release-pipeline.yml` (the documented replacement) so manual npm publishes pass the `version-type` input correctly again. The previous `publish.yml` was repurposed to a publish-only workflow that no longer accepts `version-type`, which broke release runs.

## Checklist

- [ ] Added a changelog entry
- [ ] Relevant test coverage
- [ ] Tested and confirmed flows affected by this change are functioning as expected

## Authors

> List GitHub usernames for everyone who contributed to this pull request.

### Reviewers

@braintree/team-sdk-js